### PR TITLE
meson: Explicitly add --no-as-needed to link flags.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('gst-rpicamsrc', 'c', version : '1.0.0',
   meson_version : '>= 0.34.0', default_options : ['b_asneeded=false'])
+add_project_link_arguments('-Wl,--no-as-needed', language: 'c')
 
 gst_req = '>= 1.0.0'
 


### PR DESCRIPTION
Might fix the build on ubuntu which seems to have --as-needed
by default